### PR TITLE
Add default origin for workers

### DIFF
--- a/packages/runtimes/js/src/helpers/bundle-url.js
+++ b/packages/runtimes/js/src/helpers/bundle-url.js
@@ -32,7 +32,11 @@ function getBaseURL(url) {
 
 // TODO: Replace uses with `new URL(url).origin` when ie11 is no longer supported.
 function getOrigin(url) {
-  let matches = ('' + url).match(/(https?|file|ftp):\/\/[^/]+/);
+  url = '' + url;
+  if (url[0] === '/') {
+    return self.location.origin
+  }
+  let matches = url.match(/(https?|file|ftp):\/\/[^/]+/);
   if (!matches) {
     throw new Error('Origin not found');
   }


### PR DESCRIPTION
# ↪️ Pull Request

* Changes the `getOrigin` helper in `@parcel/runtime-js` to return `self.location.origin` if the passed URL starts with `/`.
* Possible fix for #4731, #6141, #6269.

## 💻 Examples

```json
// .parcelrc
{ "extends": "@parcel/config-default",
  "transformers": {
    "*.ts": ["@parcel/transformer-typescript-tsc"]},
  "validators": {
    "*.ts": ["@parcel/validator-typescript"]} }
```

```html
// index.html
<html>
<head></head>
<body><script type="module" src="index.ts"></script></body>
</html>
```

```js
// index.js
const worker = new Worker(
  new URL('./worker.ts', import.meta.url),
  { type: 'module' }))
```

```ts
// worker.ts
import something from './somewhere'
console.log(something())
```

```ts
// somewhere.ts
export default () => 'it works!'
```

## 🚨 Test instructions

```sh
parcel index.html
```

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
